### PR TITLE
Settings should be accessible via main menu and command palette

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -1,0 +1,10 @@
+[
+    {
+        "caption": "Preferences: ColorConvert Settings",
+        "command": "edit_settings", "args":
+        {
+            "base_file": "${packages}/ColorConvert/ColorConvert.sublime-settings",
+            "default": "// ColorConvert Settings - User\n{\n\t$0\n}\n"
+        }
+    }
+]

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -117,17 +117,6 @@
 			{
 				"caption": "Convert All Hex->ColorName",
 				"command": "color_convert_all_hex_to_name"
-			},
-			{
-				"caption": "-"
-			},
-			{
-				"caption": "Open Settings",
-				"command": "edit_settings", "args":
-				{
-					"base_file": "${packages}/ColorConvert/ColorConvert.sublime-settings",
-					"default": "${packages}/User/ColorConvert.sublime-settings"
-				}
 			}
 		]
 	},

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,29 @@
+[
+    {
+        "caption": "Preferences",
+        "id": "preferences",
+        "mnemonic": "n",
+        "children": [
+            {
+                "caption": "Package Settings",
+                "id": "package-settings",
+                "mnemonic": "P",
+                "children": [
+                    {
+                        "caption": "ColorConvert",
+                        "children": [
+                            {
+                                "caption": "Settings",
+                                "command": "edit_settings", "args":
+                                {
+                                    "base_file": "${packages}/ColorConvert/ColorConvert.sublime-settings",
+                                    "default": "// ColorConvert Settings - User\n{\n\t$0\n}\n"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
The convention in SublimeText 3 is to have the settings for a package available via Preferences >  Package Settings. Additionally, package settings should be available via the command palette. 
The current implementation via the context menu does not follow that convention. In stead, the context menu should only contain entries applicable to that context. Also, the current implementation fails if the user settings file does not exist yet. The correct way to do this is to provide not the file name (ST will manage that) but the default contents.

This pull requests removes the context menu entry and replaces it with the correct entries in the main menu and command palette. 